### PR TITLE
Fix divisions of form 0/k for Zech's logarithms

### DIFF
--- a/src/ZechLog.jl
+++ b/src/ZechLog.jl
@@ -45,6 +45,7 @@ end
 
 function zech_op(logtable, exptable, n, ::Union{typeof(/), typeof(//)}, a, b)
     iszero(b) && throw(DivideError())
+    iszero(a) && return zero(a)
     exptable[mod(logtable[a] - logtable[b], n)]
 end
 


### PR DESCRIPTION
This pull request adds the case 0/k to division using Zech's logarithms.
It fixes the following bug:
```julia
julia> using GaloisFields
julia> G = @GaloisFields! 9 b
julia> G(0)/G(1)
ERROR: KeyError: key 0 not found
```